### PR TITLE
Use #0077b6 as accent color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 :root {
   --darkblue: #1f2937;
   --white: #fff;
-  --green: #4adf86;
+  --green: #0077b6;
   --darkblue2: #273549;
   --mediumgray: #d5d4d8;
 }
@@ -91,7 +91,7 @@ body {
 /* BUTTONS */
 .generate-p-btn {
   margin-top: 30px;
-  background-color: #10b981;
+  background-color: #0077b6;
   border: none;
   border-radius: 0.375rem;
   padding: 0.6rem 1.2rem;
@@ -109,7 +109,7 @@ body {
 
 /* INPUTS */
 .length-container input {
-  color: #55f991;
+  color: #0077b6;
   font-family: Inter;
   font-size: 1rem;
   padding: 5px 10px;
@@ -120,7 +120,7 @@ body {
 
 .generated-p-field {
   width: 100%;
-  color: #55f991;
+  color: #0077b6;
   text-align: center;
   font-family: Inter;
   font-size: 1rem;


### PR DESCRIPTION
Replace the green accent with #0077b6 across styles.css: update --green in :root and apply the new color to .generate-p-btn background, .length-container input color, and .generated-p-field color. This unifies previously varying green shades (#4adf86, #10b981, #55f991) to a single accent color.